### PR TITLE
Only install cookiecutter<2.0 because of breaking API changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ documentation = "https://footing.readthedocs.io"
 [tool.poetry.dependencies]
 python = ">=3.7.0,<4"
 click = ">=6.7"
-cookiecutter = ">=1.6.0"
+cookiecutter = "<2.0.0"
 pyyaml = ">=3.12"
 python-gitlab = ">=2.10.1"
 requests = ">=2.13.0"


### PR DESCRIPTION
Type: trivial